### PR TITLE
install-proxy: auto-detect default-route interface for IP lookup

### DIFF
--- a/install/nginx-proxy/install-proxy.sh
+++ b/install/nginx-proxy/install-proxy.sh
@@ -15,8 +15,15 @@ cd $NGINX_PROXY_AUTOMATION_PATH
 
 # Get current IP Address
 NET_INTERFACES=( eth0 ens3 ens4)
+
+# Prefer the host's actual default-route interface so detection works
+# regardless of naming (e.g. ens6 on Ubuntu 24.04 / IONOS), then fall back
+# to the well-known list above for backward compatibility.
+DEFAULT_IFACE=$(ip -4 route show default 2>/dev/null | awk '{print $5; exit}')
+[[ -n "$DEFAULT_IFACE" ]] && NET_INTERFACES=( "$DEFAULT_IFACE" "${NET_INTERFACES[@]}" )
+
 for i in "${NET_INTERFACES[@]}"; do
-  NET_IP=$(ip address show $i | grep "inet\b" | head -n 1 | awk '{print $2}' | cut -d/ -f1)
+  NET_IP=$(ip address show $i 2>/dev/null | grep "inet\b" | head -n 1 | awk '{print $2}' | cut -d/ -f1)
   if [[ $NET_IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     break
   fi


### PR DESCRIPTION
## Problem

`install/nginx-proxy/install-proxy.sh` discovers the server's IP by probing a hardcoded interface list:

```sh
NET_INTERFACES=( eth0 ens3 ens4)
```

On hosts whose primary NIC has a different name this loop never finds an IP, so `NET_IP` is empty and `fresh-start.sh` is invoked with an empty `--ip-address`, aborting the install:

```
We could not identify your IP Address, please update the .env and restart the nginx-proxy!
✘ ERROR   Invalid option for --ip-address
```

Ubuntu 24.04 and IONOS VPS name the primary interface `ens6`, which is not in the list, so the install fails out of the box there.

## Fix

Detect the host's actual default-route interface with `ip route` and prepend it to the existing list, keeping the well-known names as a fallback:

```sh
DEFAULT_IFACE=$(ip -4 route show default 2>/dev/null | awk '{print $5; exit}')
[[ -n "$DEFAULT_IFACE" ]] && NET_INTERFACES=( "$DEFAULT_IFACE" "${NET_INTERFACES[@]}" )
```

- **Backward compatible** — hosts that already worked keep matching `eth0/ens3/ens4` via the fallback list.
- Works regardless of interface naming (`ens6`, `enp0s3`, `eno1`, etc.).
- Also adds `2>/dev/null` to `ip address show` to silence "Device does not exist" warnings for absent NICs.

## Testing

On a fresh Ubuntu 24.04 host whose primary interface is `ens6`, I ran both detection blocks directly:

- **Original** logic leaves `NET_IP` empty (reproduces the abort).
- **Patched** logic in this PR detects `ens6` via `ip route` and resolves `NET_IP` to the correct public IP.
- `bash -n install-proxy.sh` passes.

The same problem was hit on three separate Ubuntu 24.04 hosts; the equivalent fix (extending the interface list) was applied there to complete the install. This PR generalises it via auto-detection so no host-specific list edits are needed.